### PR TITLE
fix: Images were loading from the API in an infinite loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "node test/frontend.test.js"
   },
   "dependencies": {
     "dotenv": "^16.4.5",

--- a/public/js/components/search.js
+++ b/public/js/components/search.js
@@ -1,33 +1,48 @@
-// Função para buscar exercícios na API
+let searchTimeoutId;
+let searchController;
+
 async function searchExercises(query) {
     try {
-        const response = await fetch(`https://libapi.vercel.app/api/exercises/search?lang=pt&query=${query}`);
+        if (searchController) {
+            searchController.abort();
+        }
+
+        searchController = new AbortController();
+        const response = await fetch(`${apiBaseUrl}/api/exercises/search?lang=pt&query=${encodeURIComponent(query)}`, {
+            signal: searchController.signal,
+        });
+
         if (!response.ok) {
             throw new Error(`Erro na API: ${response.statusText}`);
         }
 
         const data = await response.json();
+
         if (data.exercises && data.exercises.length > 0) {
-            // Emite um evento com os resultados da pesquisa
             document.dispatchEvent(new CustomEvent('searchResults', { detail: data.exercises }));
         } else {
             console.warn('Nenhum exercício encontrado para a pesquisa:', query);
             clearSearchResults();
         }
     } catch (error) {
+        if (error.name === 'AbortError') {
+            return;
+        }
+
         console.error('Erro ao buscar exercícios:', error);
         clearSearchResults();
+    } finally {
+        searchController = null;
     }
 }
 
-// Função para limpar os resultados da pesquisa
 function clearSearchResults() {
     document.dispatchEvent(new CustomEvent('clearSearchResults'));
 }
 
-// Função para criar uma barra de pesquisa e colocá-la no placeholder
 function createSearchBar() {
     const searchPlaceholder = document.getElementById('search-placeholder');
+
     if (!searchPlaceholder) {
         console.error('Placeholder da barra de pesquisa não encontrado!');
         return;
@@ -46,21 +61,26 @@ function createSearchBar() {
 
     searchContainer.appendChild(searchInput);
     searchContainer.appendChild(searchIcon);
-
-    // Insere a barra de pesquisa no placeholder
     searchPlaceholder.appendChild(searchContainer);
 
-    // Adiciona o evento de pesquisa
     searchInput.addEventListener('input', (e) => {
         const query = e.target.value.trim().toLowerCase();
-        if (query) {
-            searchExercises(query);
-        } else {
+
+        clearTimeout(searchTimeoutId);
+
+        if (!query) {
+            if (searchController) {
+                searchController.abort();
+            }
+
             clearSearchResults();
-            fetchExercises(0); // Exibe a lista padrão ao limpar a barra de pesquisa
+            return;
         }
+
+        searchTimeoutId = window.setTimeout(() => {
+            searchExercises(query);
+        }, 250);
     });
 }
 
-// Chama a função para criar a barra de pesquisa quando a página carrega
 createSearchBar();

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,103 +1,136 @@
 let currentPage = 0;
 const exercisesPerPage = 50;
-let loading = false; // Para prevenir múltiplos carregamentos simultâneos
+let loading = false;
+let isShowingSearchResults = false;
 const apiBaseUrl = 'https://libapi.vercel.app';
+let renderedCardCount = 0;
 
-// Função para buscar exercícios
+const revealObserver = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+            return;
+        }
+
+        entry.target.classList.add('show');
+        revealObserver.unobserve(entry.target);
+    });
+}, {
+    threshold: 0.15,
+});
+
 async function fetchExercises(page = 0, limit = exercisesPerPage) {
     try {
-        loading = true; // Impede múltiplas chamadas simultâneas
+        loading = true;
         const response = await fetch(`${apiBaseUrl}/api/exercises?lang=pt&page=${page}&limit=${limit}`);
-            if (!response.ok) {
-                throw new Error(`Erro na resposta da API: ${response.statusText}`);
-            }
+
+        if (!response.ok) {
+            throw new Error(`Erro na resposta da API: ${response.statusText}`);
+        }
 
         const exercises = await response.json();
-        
+
         if (exercises.length > 0) {
             displayExercises(exercises);
-            currentPage++; // Incrementa a página
+            currentPage++;
         }
-        
-        loading = false; // Libera para próxima chamada
+
+        loading = false;
     } catch (err) {
         console.error('Erro ao buscar exercícios:', err);
-            // alert('Ocorreu um erro ao buscar os exercicíos. Tente novamente mais tarde.');
-        loading = false; // Libera a chamada caso ocorra erro
+        loading = false;
     }
 }
 
-// Função para verificar se o elemento está parcialmente visível na janela de visualização
-function isElementInViewport(el) {
-    const rect = el.getBoundingClientRect();
-    return (
-        rect.top < window.innerHeight * 0.85 && // Se a parte superior estiver 85% visível na tela
-        rect.bottom > 0 // Se a parte inferior ainda não tiver passado da tela
-    );
+function resetExercisesContainer() {
+    const container = document.getElementById('exercises-container');
+
+    if (!container) {
+        return null;
+    }
+
+    container.querySelectorAll('.exercise-card').forEach((card) => {
+        revealObserver.unobserve(card);
+    });
+
+    container.replaceChildren();
+    renderedCardCount = 0;
+
+    return container;
 }
 
-// Função para exibir os exercícios
 function displayExercises(exercises) {
     const container = document.getElementById('exercises-container');
+
+    if (!container) {
+        return;
+    }
 
     exercises.forEach((exercise, index) => {
         const exerciseCard = document.createElement('div');
         exerciseCard.className = 'exercise-card';
 
-        // Verifica se há imagens e usa ambas
         if (exercise.images && exercise.images.length > 0) {
             const img = document.createElement('img');
-            img.src = `${apiBaseUrl}/exercises/${exercise.images[0]}`; // Usa a primeira imagem inicialmente
+            const primaryImage = `${apiBaseUrl}/${exercise.images[0]}`;
+            const secondaryImage = exercise.images[1] ? `${apiBaseUrl}/${exercise.images[1]}` : null;
+
+            img.src = primaryImage;
             img.alt = exercise.name;
+            img.loading = 'lazy';
+            img.decoding = 'async';
             exerciseCard.appendChild(img);
 
-            // Alternar imagens
-            let currentIndex = 0;
-            setInterval(() => {
-                currentIndex = (currentIndex + 1) % exercise.images.length;
-                img.src = `${apiBaseUrl}/exercises/${exercise.images[currentIndex]}`; // Atualiza a imagem
-            }, 1500); // Muda a imagem a cada 1,5 segundo (1500 milissegundos)
+            if (secondaryImage) {
+                const showSecondaryImage = () => {
+                    img.src = secondaryImage;
+                };
+
+                const showPrimaryImage = () => {
+                    img.src = primaryImage;
+                };
+
+                exerciseCard.addEventListener('mouseenter', showSecondaryImage);
+                exerciseCard.addEventListener('mouseleave', showPrimaryImage);
+                exerciseCard.addEventListener('focusin', showSecondaryImage);
+                exerciseCard.addEventListener('focusout', showPrimaryImage);
+            }
         }
 
-        // Adiciona o nome do exercício
         const name = document.createElement('h3');
         name.textContent = exercise.name;
         exerciseCard.appendChild(name);
 
-        // Adiciona o nível e categoria
         const details = document.createElement('p');
         details.textContent = `Nível: ${exercise.level} | Categoria: ${exercise.category}`;
         exerciseCard.appendChild(details);
 
-        // Adiciona a força
         const force = document.createElement('p');
         force.textContent = `Força: ${exercise.force}`;
         exerciseCard.appendChild(force);
 
-        // Adiciona o equipamento (se houver)
         const equipment = document.createElement('p');
         equipment.textContent = `Equipamento: ${exercise.equipment || 'Nenhum'}`;
         exerciseCard.appendChild(equipment);
 
-        // Adiciona os músculos principais
         const primaryMuscles = document.createElement('p');
         primaryMuscles.textContent = `Músculo Principal: ${exercise.primaryMuscles.join(', ')}`;
         exerciseCard.appendChild(primaryMuscles);
 
-        // Adiciona os músculos secundários (se houver)
         const secondaryMuscles = document.createElement('p');
-        secondaryMuscles.textContent = `Músculos Secundários: ${exercise.secondaryMuscles && Array.isArray(exercise.secondaryMuscles) && exercise.secondaryMuscles.length > 0 ? exercise.secondaryMuscles.join(', ') : 'Nenhum'}`;
+        secondaryMuscles.textContent = `Músculos Secundários: ${exercise.secondaryMuscles && Array.isArray(exercise.secondaryMuscles) && exercise.secondaryMuscles.length > 0
+            ? exercise.secondaryMuscles.join(', ')
+            : 'Nenhum'
+            }`;
         exerciseCard.appendChild(secondaryMuscles);
 
-        // Adiciona as instruções em um colapso
-        const collapseId = `collapseInstructions-${index}`;
+        const collapseId = `collapseInstructions-${renderedCardCount + index}`;
 
         const collapseButton = document.createElement('button');
         collapseButton.className = 'collapse-btn btn btn-primary collapse-toggle d-flex justify-content-between align-items-center';
         collapseButton.type = 'button';
         collapseButton.setAttribute('data-bs-toggle', 'collapse');
         collapseButton.setAttribute('data-bs-target', `#${collapseId}`);
-        collapseButton.innerHTML = `Mostrar Instruções <i class="collapse-icon fas fa-plus"></i>`; // Ícone do Font Awesome
+        collapseButton.innerHTML = 'Mostrar Instruções <i class="collapse-icon fas fa-plus"></i>';
         exerciseCard.appendChild(collapseButton);
 
         const collapseDiv = document.createElement('div');
@@ -108,7 +141,7 @@ function displayExercises(exercises) {
         instructions.className = 'card card-body';
 
         if (exercise.instructions && Array.isArray(exercise.instructions)) {
-            exercise.instructions.forEach(step => {
+            exercise.instructions.forEach((step) => {
                 const p = document.createElement('p');
                 p.textContent = step;
                 instructions.appendChild(p);
@@ -118,68 +151,50 @@ function displayExercises(exercises) {
         collapseDiv.appendChild(instructions);
         exerciseCard.appendChild(collapseDiv);
 
-        // Função para alternar ícone de + para x
         collapseButton.addEventListener('click', () => {
             const icon = collapseButton.querySelector('.collapse-icon');
+
             if (collapseDiv.classList.contains('show')) {
-                icon.classList.replace('fa-minus', 'fa-plus'); // Alterna para o ícone de +
+                icon.classList.replace('fa-minus', 'fa-plus');
             } else {
-                icon.classList.replace('fa-plus', 'fa-minus'); // Alterna para o ícone de x
+                icon.classList.replace('fa-plus', 'fa-minus');
             }
         });
 
-        // Evento do Bootstrap para detectar quando o colapso abrir ou fechar
         collapseDiv.addEventListener('shown.bs.collapse', () => {
             const icon = collapseButton.querySelector('.collapse-icon');
-            icon.classList.replace('fa-plus', 'fa-minus'); // Ícone de colapso aberto
+            icon.classList.replace('fa-plus', 'fa-minus');
         });
 
         collapseDiv.addEventListener('hidden.bs.collapse', () => {
             const icon = collapseButton.querySelector('.collapse-icon');
-            icon.classList.replace('fa-minus', 'fa-plus'); // Ícone de colapso fechado
+            icon.classList.replace('fa-minus', 'fa-plus');
         });
 
-
-        // Adiciona o card ao container
         container.appendChild(exerciseCard);
-           
-
-        // Função para revelar o card quando ele entra parcialmente na visualização
-        function reveal() {
-            if (isElementInViewport(exerciseCard)) {
-                exerciseCard.classList.add('show');
-            }
-        }
-
-        // Verifica se o card está visível no carregamento
-        reveal();
-
-        // Adiciona um event listener para rolar
-        window.addEventListener('scroll', reveal);
+        revealObserver.observe(exerciseCard);
     });
+
+    renderedCardCount += exercises.length;
 }
 
-// Função para carregar mais exercícios conforme a rolagem
 window.addEventListener('scroll', () => {
-    if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 200 && !loading) {
-        fetchExercises(currentPage); // Carrega a próxima página
+    if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 200 && !loading && !isShowingSearchResults) {
+        fetchExercises(currentPage);
     }
 });
 
 document.addEventListener('searchResults', (e) => {
-    const exercises = e.detail; // Exercícios retornados
-    const container = document.getElementById('exercises-container');
-    container.innerHTML = ''; // Limpa os exercícios atuais para exibir os resultados da pesquisa
-    displayExercises(exercises);
+    isShowingSearchResults = true;
+    resetExercisesContainer();
+    displayExercises(e.detail);
 });
 
 document.addEventListener('clearSearchResults', () => {
-    const container = document.getElementById('exercises-container');
-    container.innerHTML = ''; // Limpa os resultados da pesquisa
-    currentPage = 0; // Reseta a paginação para a primeira página
-    fetchExercises(0); // Carrega os exercícios da primeira página
+    isShowingSearchResults = false;
+    resetExercisesContainer();
+    currentPage = 0;
+    fetchExercises(0);
 });
 
-
-// Carrega a primeira página de exercícios ao carregar o site
 fetchExercises();

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -1,0 +1,453 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createClassList() {
+    const classes = new Set();
+
+    return {
+        add(name) {
+            classes.add(name);
+        },
+        remove(name) {
+            classes.delete(name);
+        },
+        replace(from, to) {
+            if (classes.has(from)) {
+                classes.delete(from);
+            }
+
+            classes.add(to);
+        },
+        contains(name) {
+            return classes.has(name);
+        },
+    };
+}
+
+function createElement(tagName) {
+    return {
+        tagName,
+        children: [],
+        attributes: {},
+        listeners: {},
+        className: '',
+        classList: createClassList(),
+        style: {},
+        innerHTML: '',
+        textContent: '',
+        appendChild(child) {
+            child.parentNode = this;
+            this.children.push(child);
+            return child;
+        },
+        replaceChildren(...children) {
+            this.children = [];
+            children.forEach((child) => this.appendChild(child));
+        },
+        setAttribute(name, value) {
+            this.attributes[name] = value;
+        },
+        addEventListener(type, handler) {
+            if (!this.listeners[type]) {
+                this.listeners[type] = [];
+            }
+
+            this.listeners[type].push(handler);
+        },
+        dispatchEvent(event) {
+            const handlers = this.listeners[event.type] || [];
+            handlers.forEach((handler) => handler(event));
+        },
+        querySelector(selector) {
+            if (selector === '.collapse-icon') {
+                return { classList: createClassList() };
+            }
+
+            return null;
+        },
+        querySelectorAll(selector) {
+            if (selector === '.exercise-card') {
+                return this.children.filter((child) => child.className === 'exercise-card');
+            }
+
+            return [];
+        },
+    };
+}
+
+function createTimerController() {
+    let nextId = 1;
+    const timers = new Map();
+
+    return {
+        setTimeout(callback, delay) {
+            const id = nextId++;
+            timers.set(id, { callback, delay });
+            return id;
+        },
+        clearTimeout(id) {
+            timers.delete(id);
+        },
+        runAll() {
+            const pending = [...timers.entries()];
+            timers.clear();
+            pending.forEach(([, timer]) => timer.callback());
+        },
+        count() {
+            return timers.size;
+        },
+    };
+}
+
+function createScriptEnvironment() {
+    const timerController = createTimerController();
+    const intervalCalls = [];
+    const fetchCalls = [];
+    const observerInstances = [];
+    const documentListeners = {};
+    const windowListeners = {};
+    const exercisesContainer = createElement('div');
+
+    exercisesContainer.id = 'exercises-container';
+
+    const document = {
+        addEventListener(type, handler) {
+            if (!documentListeners[type]) {
+                documentListeners[type] = [];
+            }
+
+            documentListeners[type].push(handler);
+        },
+        dispatchEvent(event) {
+            const handlers = documentListeners[event.type] || [];
+            handlers.forEach((handler) => handler(event));
+        },
+        getElementById(id) {
+            if (id === 'exercises-container') {
+                return exercisesContainer;
+            }
+
+            return null;
+        },
+        createElement,
+        body: {
+            offsetHeight: 1000,
+        },
+    };
+
+    const window = {
+        innerHeight: 900,
+        scrollY: 0,
+        addEventListener(type, handler) {
+            if (!windowListeners[type]) {
+                windowListeners[type] = [];
+            }
+
+            windowListeners[type].push(handler);
+        },
+        setTimeout: timerController.setTimeout,
+        clearTimeout: timerController.clearTimeout,
+    };
+
+    class FakeIntersectionObserver {
+        constructor(callback, options) {
+            this.callback = callback;
+            this.options = options;
+            this.observed = [];
+            this.unobserved = [];
+            observerInstances.push(this);
+        }
+
+        observe(target) {
+            this.observed.push(target);
+        }
+
+        unobserve(target) {
+            this.unobserved.push(target);
+        }
+    }
+
+    const context = {
+        console,
+        window,
+        document,
+        IntersectionObserver: FakeIntersectionObserver,
+        fetch(url) {
+            fetchCalls.push(url);
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve([{
+                    name: 'Push Up',
+                    images: ['exercises/push-up/0.jpg', 'exercises/push-up/1.jpg'],
+                    level: 'beginner',
+                    category: 'strength',
+                    force: 'push',
+                    equipment: null,
+                    primaryMuscles: ['chest'],
+                    secondaryMuscles: ['triceps'],
+                    instructions: ['Step 1'],
+                }]),
+            });
+        },
+        setInterval(callback, delay) {
+            intervalCalls.push({ callback, delay });
+            return intervalCalls.length;
+        },
+        clearInterval() {},
+        CustomEvent: class CustomEvent {
+            constructor(type, init = {}) {
+                this.type = type;
+                this.detail = init.detail;
+            }
+        },
+    };
+
+    context.global = context;
+    context.globalThis = context;
+    context.self = context;
+    context.window.document = document;
+    context.window.CustomEvent = context.CustomEvent;
+
+    return {
+        context,
+        document,
+        window,
+        fetchCalls,
+        intervalCalls,
+        observerInstances,
+        windowListeners,
+        exercisesContainer,
+    };
+}
+
+function createSearchEnvironment({ keepFetchPending = false } = {}) {
+    const timerController = createTimerController();
+    const fetchCalls = [];
+    const dispatchedEvents = [];
+    const placeholder = createElement('div');
+    const documentListeners = {};
+
+    let currentAbortSignal = null;
+    let pendingFetchResolve = null;
+
+    const document = {
+        addEventListener(type, handler) {
+            if (!documentListeners[type]) {
+                documentListeners[type] = [];
+            }
+
+            documentListeners[type].push(handler);
+        },
+        dispatchEvent(event) {
+            dispatchedEvents.push(event);
+            const handlers = documentListeners[event.type] || [];
+            handlers.forEach((handler) => handler(event));
+        },
+        getElementById(id) {
+            if (id === 'search-placeholder') {
+                return placeholder;
+            }
+
+            return null;
+        },
+        createElement,
+    };
+
+    const window = {
+        setTimeout: timerController.setTimeout,
+        clearTimeout: timerController.clearTimeout,
+    };
+
+    const context = {
+        console,
+        window,
+        document,
+        setTimeout: timerController.setTimeout,
+        clearTimeout: timerController.clearTimeout,
+        apiBaseUrl: 'https://libapi.vercel.app',
+        fetchExercises() {
+            throw new Error('search.js should not call fetchExercises directly when clearing');
+        },
+        fetch(url, options = {}) {
+            fetchCalls.push({ url, options });
+            currentAbortSignal = options.signal;
+
+            if (keepFetchPending) {
+                return new Promise((resolve) => {
+                    pendingFetchResolve = () => resolve({
+                        ok: true,
+                        json: () => Promise.resolve({
+                            exercises: [{ name: 'Push Up' }],
+                        }),
+                    });
+                });
+            }
+
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({
+                    exercises: [{ name: 'Push Up' }],
+                }),
+            });
+        },
+        AbortController,
+        CustomEvent: class CustomEvent {
+            constructor(type, init = {}) {
+                this.type = type;
+                this.detail = init.detail;
+            }
+        },
+    };
+
+    context.global = context;
+    context.globalThis = context;
+    context.self = context;
+    context.window.document = document;
+    context.window.CustomEvent = context.CustomEvent;
+
+    return {
+        context,
+        placeholder,
+        timerController,
+        fetchCalls,
+        dispatchedEvents,
+        getCurrentAbortSignal() {
+            return currentAbortSignal;
+        },
+        resolvePendingFetch() {
+            if (pendingFetchResolve) {
+                pendingFetchResolve();
+                pendingFetchResolve = null;
+            }
+        },
+    };
+}
+
+function loadScript(relativePath, context) {
+    const filePath = path.join(__dirname, '..', relativePath);
+    const source = fs.readFileSync(filePath, 'utf8');
+    vm.runInNewContext(source, context, { filename: filePath });
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function runTest(name, fn) {
+    try {
+        await fn();
+        console.log(`PASS ${name}`);
+    } catch (error) {
+        console.error(`FAIL ${name}`);
+        console.error(error);
+        process.exitCode = 1;
+    }
+}
+
+async function main() {
+    await runTest('script.js renders cards without creating looping image intervals', async () => {
+        const env = createScriptEnvironment();
+
+        loadScript(path.join('public', 'js', 'script.js'), env.context);
+        await flushPromises();
+
+        assert.equal(env.fetchCalls.length, 1);
+        assert.equal(env.intervalCalls.length, 0);
+        assert.equal(env.exercisesContainer.children.length, 1);
+
+        const card = env.exercisesContainer.children[0];
+        const image = card.children[0];
+
+        assert.equal(image.src, 'https://libapi.vercel.app/exercises/push-up/0.jpg');
+        assert.equal(image.loading, 'lazy');
+        assert.equal(env.observerInstances[0].observed.length, 1);
+    });
+
+    await runTest('script.js blocks infinite scroll while search results are active and resets cleanly', async () => {
+        const env = createScriptEnvironment();
+
+        loadScript(path.join('public', 'js', 'script.js'), env.context);
+        await flushPromises();
+
+        const initialCard = env.exercisesContainer.children[0];
+        env.document.dispatchEvent({
+            type: 'searchResults',
+            detail: [{
+                name: 'Squat',
+                images: ['/squat/0.jpg'],
+                level: 'beginner',
+                category: 'strength',
+                force: 'push',
+                equipment: null,
+                primaryMuscles: ['legs'],
+                secondaryMuscles: [],
+                instructions: ['Step 1'],
+            }],
+        });
+
+        env.window.scrollY = 200;
+        env.windowListeners.scroll[0]();
+        await flushPromises();
+
+        assert.equal(env.fetchCalls.length, 1);
+        assert.equal(env.observerInstances[0].unobserved[0], initialCard);
+
+        env.document.dispatchEvent({ type: 'clearSearchResults' });
+        await flushPromises();
+
+        assert.equal(env.fetchCalls.length, 2);
+    });
+
+    await runTest('search.js debounces input and encodes the query before fetching', async () => {
+        const env = createSearchEnvironment();
+
+        loadScript(path.join('public', 'js', 'components', 'search.js'), env.context);
+
+        const searchContainer = env.placeholder.children[0];
+        const input = searchContainer.children[0];
+
+        input.dispatchEvent({ type: 'input', target: { value: 'push' } });
+        input.dispatchEvent({ type: 'input', target: { value: 'push up' } });
+
+        assert.equal(env.timerController.count(), 1);
+        assert.equal(env.fetchCalls.length, 0);
+
+        env.timerController.runAll();
+        await flushPromises();
+
+        assert.equal(env.fetchCalls.length, 1);
+        assert.match(env.fetchCalls[0].url, /query=push%20up/);
+        assert.equal(env.dispatchedEvents.at(-1).type, 'searchResults');
+    });
+
+    await runTest('search.js aborts in-flight searches and clears via event only once', async () => {
+        const env = createSearchEnvironment({ keepFetchPending: true });
+
+        loadScript(path.join('public', 'js', 'components', 'search.js'), env.context);
+
+        const searchContainer = env.placeholder.children[0];
+        const input = searchContainer.children[0];
+
+        input.dispatchEvent({ type: 'input', target: { value: 'push' } });
+        env.timerController.runAll();
+        await flushPromises();
+
+        const activeSignal = env.getCurrentAbortSignal();
+        assert.equal(activeSignal.aborted, false);
+
+        input.dispatchEvent({ type: 'input', target: { value: '' } });
+
+        assert.equal(activeSignal.aborted, true);
+        assert.equal(env.dispatchedEvents.at(-1).type, 'clearSearchResults');
+
+        env.resolvePendingFetch();
+        await flushPromises();
+    });
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
In /script.js#L61, I removed the per-card `setInterval` behavior entirely and replaced it with a simple hover/focus image swap at script.js#L72. That stops the endless `/0.jpg` `/1.jpg` loop and reduces image requests to the initial image plus an optional second image only when the user interacts with a card. I also added `loading="lazy"` and `decoding="async"` there.

I also fixed the rerender lifecycle in /script.js#L44 by centralizing container cleanup and replacing the old “one `scroll` listener per card” pattern with a single `IntersectionObserver` at /script.js#L8. On top of that, search mode is now isolated from infinite scroll at /script.js#L182, so scrolling filtered results won’t append the default catalog underneath.

In /search.js#L4, I added request cancellation plus a 250ms debounce, and I removed the extra direct `fetchExercises(0)` call on clear. Clearing the search now goes through one path only, so the default list reloads once instead of twice.